### PR TITLE
Add aim assist toggle keybind

### DIFF
--- a/Aimmy2/Class/Dictionary.cs
+++ b/Aimmy2/Class/Dictionary.cs
@@ -13,6 +13,7 @@ namespace Aimmy2.Class
         {
             { "Aim Keybind", "Right"},
             { "Second Aim Keybind", "LMenu"},
+            { "Aim Assist Toggle Keybind", "F1"},
             { "Dynamic FOV Keybind", "Left"},
             { "Emergency Stop Keybind", "Delete"},
             { "Model Switch Keybind", "OemPipe"},

--- a/Aimmy2/Class/UI.cs
+++ b/Aimmy2/Class/UI.cs
@@ -12,6 +12,7 @@ namespace Class
         public AToggle? T_AimAligner { get; set; }
 
         public AKeyChanger? C_Keybind { get; set; }
+        public AKeyChanger? C_AimToggleKeybind { get; set; }
         public AToggle? T_ConstantAITracking { get; set; }
         public AToggle? T_StickyAim { get; set; }
         public AToggle? T_Predictions { get; set; }

--- a/Aimmy2/MainWindow.xaml.cs
+++ b/Aimmy2/MainWindow.xaml.cs
@@ -264,7 +264,7 @@ namespace Aimmy2
         {
             var keybinds = new[]
             {
-                "Aim Keybind", "Second Aim Keybind", "Dynamic FOV Keybind",
+                "Aim Keybind", "Second Aim Keybind", "Aim Assist Toggle Keybind", "Dynamic FOV Keybind",
                 "Emergency Stop Keybind", "Model Switch Keybind",
                 "Anti Recoil Keybind", "Disable Anti Recoil Keybind",
                 "Gun 1 Key", "Gun 2 Key"
@@ -728,7 +728,8 @@ namespace Aimmy2
                 ["Anti Recoil Keybind"] = () => HandleAntiRecoil(true),
                 ["Disable Anti Recoil Keybind"] = DisableAntiRecoil,
                 ["Gun 1 Key"] = () => LoadGunConfig("Gun 1 Config"),
-                ["Gun 2 Key"] = () => LoadGunConfig("Gun 2 Config")
+                ["Gun 2 Key"] = () => LoadGunConfig("Gun 2 Config"),
+                ["Aim Assist Toggle Keybind"] = ToggleAimAssist
             };
 
             handlers.GetValueOrDefault(bindingId)?.Invoke();
@@ -743,6 +744,27 @@ namespace Aimmy2
             };
 
             handlers.GetValueOrDefault(bindingId)?.Invoke();
+        }
+
+        private void ToggleAimAssist()
+        {
+            if (!Dictionary.toggleState["Aim Assist"])
+            {
+                if (Dictionary.lastLoadedModel == "N/A")
+                {
+                    LogManager.Log(LogManager.LogLevel.Warning, "Please load a model first", true);
+                    return;
+                }
+            }
+
+            Dictionary.toggleState["Aim Assist"] = !Dictionary.toggleState["Aim Assist"];
+            UpdateToggleUI(uiManager.T_AimAligner!, Dictionary.toggleState["Aim Assist"]);
+            Toggle_Action("Aim Assist");
+
+            var message = Dictionary.toggleState["Aim Assist"]
+                ? "[Aim Assist Keybind] Enabled Aim Assist."
+                : "[Aim Assist Keybind] Disabled Aim Assist.";
+            LogManager.Log(LogManager.LogLevel.Info, message, true);
         }
 
         private void HandleModelSwitch()

--- a/Aimmy2/UISections/AimMenuControl.xaml.cs
+++ b/Aimmy2/UISections/AimMenuControl.xaml.cs
@@ -173,6 +173,7 @@ namespace Aimmy2.Controls
                 })
                 .AddKeyChanger("Aim Keybind", k => uiManager.C_Keybind = k)
                 .AddKeyChanger("Second Aim Keybind")
+                .AddKeyChanger("Aim Assist Toggle Keybind", k => uiManager.C_AimToggleKeybind = k)
                 .AddToggle("Sticky Aim", t => uiManager.T_StickyAim = t)
                 .AddToggle("Constant AI Tracking", t =>
                 {


### PR DESCRIPTION
## Summary
- allow binding a key to toggle Aim Assist on and off
- expose Aim Assist toggle keybind in UI and configuration

## Testing
- `dotnet build` *(fails: imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec157df50832b8437bc95c343c79a